### PR TITLE
add support for SASS

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -27,7 +27,6 @@
 @import "../components/badge/css/badge";
 @import "../components/notification/css/notification";
 @import "../components/header/css/header";
-@import "../components/header/css/header-no-js";
 @import "../components/footer/css/footer";
 @import "../components/article/css/article";
 @import "../components/statement/css/statement";

--- a/css/style.scss
+++ b/css/style.scss
@@ -1,0 +1,57 @@
+@import "reset";
+@import "variables";
+@import "themes";
+@import "animation";
+@import "icons";
+@import "typography";
+
+/* INPUTS */
+
+@import "../components/inputs/css/inputs";
+
+/* ARTICLE */
+
+@import "../components/article/css/article";
+
+/* INTRO  */
+
+@import "../components/intro/css/intro";
+@import "../components/hint/css/hint";
+
+/* COMPONENTS  */
+
+@import "../components/tabs/css/tabs";
+@import "../components/filters/css/filters";
+@import "../components/about/css/about";
+@import "../components/buttons/css/links-buttons";
+@import "../components/badge/css/badge";
+@import "../components/notification/css/notification";
+@import "../components/header/css/header";
+@import "../components/header/css/header-no-js";
+@import "../components/footer/css/footer";
+@import "../components/article/css/article";
+@import "../components/statement/css/statement";
+@import "../components/pinned-list/css/pinned-list";
+
+/* LISTS */
+
+@import "../components/content/css/content";
+@import "../components/content/css/tertiary";
+@import "../components/content/css/primary";
+
+/* BASE */
+
+@import "base";
+@import "firefox";
+
+/* TABLE  */
+
+@import "../components/table/css/table";
+
+/* CHAT  */
+
+@import "../components/chat/css/chat";
+
+/* BUILDER  */
+
+@import "../builder/css/builder";


### PR DESCRIPTION
This file allows all the CSS to be parsed using SASS. Even though there is no SASS specific markup in any of the CSS files, the advantage of doing this is that the SASS processor will combine all the CSS into one file, and potentially compress it if desired.

For examples, suppose this in Jekyll:

pages/_includes/head.html:
```
  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
```

pages/assets/css/main.scss:
```
---
# This ensures Jekyll reads the file to be transformed into CSS later.
# Only main.scss files contain this front matter, not partials.
# All CSS is in _sass directory
---

@import "design-system/css/style.scss";
```

Then all the "design-system" directories live in "pages/_sass/design-system".

The result is that the single url /assets/css/main.css will have the compiled version of all the design-system css files together in one file.
