### PR TITLE
tables in tiny view: don't hide first tr

### DIFF
--- a/components/table/css/table.css
+++ b/components/table/css/table.css
@@ -241,7 +241,7 @@ th, td {
     opacity: 1;
   }
 
-  tr:first-of-type {
+  thead {
     display: none;
   }
 


### PR DESCRIPTION
this change hides thead instead of tr for tables in very small views. tr:first-of-type selector is  too broad, because it might also apply to the first data row. the limitations of this change is that not all tables will have a thead.